### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,14 +1,20 @@
 {
-  "name":    "simp-site",
-  "version": "2.0.1",
-  "author":  "simp",
+  "name": "simp-site",
+  "version": "2.0.2",
+  "author": "simp",
   "summary": "A skeleton profile module",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-site",
+  "source": "https://github.com/simp/pupmod-simp-site",
   "project_page": "https://github.com/simp/pupmod-simp-site",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "site", "profiles" ],
-  "dependencies": [ ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "site",
+    "profiles"
+  ],
+  "dependencies": [
+
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-site`
SIMP-1615 #close