### PR TITLE
(SIMP-2870) Fix metadata pupmod-simp-site

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
-* Mon Dec 19 2016 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.2-0
+* Tue Feb 21 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.3-0
+- Fix travis test
+
+* Mon Dec 19 2016 Nick Markowski <nmarkowski@keywcorp.com> - 2.0.3-0
 - Removed package metadata
+
+* Fri Nov 18 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.0.2-0
+- Remove `compliance_markup` and provides general housekeeping 
 
 * Mon Aug 15 2016 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
 - Moved to semantic versioning

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-site",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "SIMP Team",
   "summary": "A skeleton profile module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Last tagged version, 2.0.2, was not recorded properly in CHANGELOG.
Recorded that version in CHANGELOG and then adjusted version and CHANGELOG to reflect two
subsequent commits.

SIMP-2870 #close