### PR TITLE
(SIMP-3288) Add empty spec test for travis

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,4 +2,3 @@
 fixtures:
   symlinks:
     site: "#{source_dir}"
-    stdlib: "#{source_dir}/../stdlib"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Jun 08 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.4-0
+- Add empty spec test so travis will pass
+
 * Tue Feb 21 2017 Nick Miller <nick.miller@onyxpoint.com> - 2.0.3-0
 - Fix travis test
 
@@ -5,7 +8,7 @@
 - Removed package metadata
 
 * Fri Nov 18 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.0.2-0
-- Remove `compliance_markup` and provides general housekeeping 
+- Remove `compliance_markup` and provides general housekeeping
 
 * Mon Aug 15 2016 Nick Miller <nick.miller@onyxpoint.com> - 2.0.1-0
 - Moved to semantic versioning

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-site",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "author": "SIMP Team",
   "summary": "A skeleton profile module",
   "license": "Apache-2.0",

--- a/spec/classes/site_spec.rb
+++ b/spec/classes/site_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+puts 'This module has no code in it, so there are no real tests!'
+puts 'Here is a whale.'
+puts <<-EOF
+▄██████████████▄▐█▄▄▄▄█▌
+██████▌▄▌▄▐▐▌███▌▀▀██▀▀
+████▄█▌▄▌▄▐▐▌▀███▄▄█▌
+▄▄▄▄▄██████████████
+EOF
+
+describe 'site' do
+  context 'on supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context 'default params' do
+        it { expect(true).to be_truthy }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,92 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet'
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
+
+require 'pathname'
+
+# RSpec Material
+fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
+
+default_hiera_config =<<-EOM
+---
+:backends:
+  - "rspec"
+  - "yaml"
+:yaml:
+  :datadir: "stub"
+:hierarchy:
+  - "%{custom_hiera}"
+  - "%{spec_title}"
+  - "%{module_name}"
+  - "default"
+EOM
+
+
+['hieradata','modules'].each do |dir|
+  _dir = File.join(fixture_path,dir)
+  FileUtils.mkdir_p(_dir) unless File.directory?(_dir)
+end
+
+RSpec.configure do |c|
+  # If nothing else...
+  c.default_facts = {
+    :production => {
+      #:fqdn           => 'production.rspec.test.localdomain',
+      :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+      :concat_basedir => '/tmp'
+    }
+  }
+
+  c.mock_framework = :rspec
+  c.mock_with :mocha
+
+  c.module_path = File.join(fixture_path, 'modules')
+  c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
+
+  # Useless backtrace noise
+  backtrace_exclusion_patterns = [ /spec_helper/, /gems/ ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
+  end
+
+  c.before(:all) do
+    data = YAML.load(default_hiera_config)
+    data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
+    File.open(c.hiera_config, 'w') do |f|
+      f.write data.to_yaml
+    end
+  end
+
+  c.before(:each) do
+    @spec_global_env_temp = Dir.mktmpdir('simpspec')
+
+    if defined?(environment)
+      FileUtils.mkdir_p(File.join(@spec_global_env_temp,environment.to_s))
+    end
+
+    # ensure the user running these tests has an accessible environmentpath
+    Puppet[:environmentpath] = @spec_global_env_temp
+    Puppet[:user] = Etc.getpwuid(Process.uid).name
+    Puppet[:group] = Etc.getgrgid(Process.gid).name
+  end
+
+  c.after(:each) do
+    FileUtils.rm_rf(@spec_global_env_temp) # clean up the mocked environmentpath
+    @spec_global_env_temp = nil
+  end
+end
+
+Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|
+  begin
+    Pathname.new(dir).realpath
+  rescue
+    fail "ERROR: The module '#{dir}' is not installed. Tests cannot continue."
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,45 @@
+require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
+end
+
+
+RSpec.configure do |c|
+  # ensure that environment OS is ready on each host
+  fix_errata_on hosts
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    begin
+      # Install modules and dependencies from spec/fixtures/modules
+      copy_fixture_modules_to( hosts )
+
+      # Generate and install PKI certificates on each SUT
+      Dir.mktmpdir do |cert_dir|
+        run_fake_pki_ca_on( default, hosts, cert_dir )
+        hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
+      end
+    rescue StandardError, ScriptError => e
+      if ENV['PRY']
+        require 'pry'; binding.pry
+      else
+        raise e
+      end
+    end
+  end
+end


### PR DESCRIPTION
This module contains no content, but still recives our module assets,
including our stock .travis.yaml. THis commit adds a basic infallible
spectest to ensure travis passes.

SIMP-3288 #close