### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 2.0.6-0
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Wed Nov 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.0.5-0
 - Update badges and contribution guide URL in README.md
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 # This module is empty on purpose, and is intended to contain site-specific classes.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-site",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "author": "SIMP Team",
   "summary": "A skeleton profile module",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-site