### PR TITLE
Add OpenVox 9 / Ruby 4.0 preview and drop the puppet gem

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,4 +1,2 @@
 ---
 fixtures:
-  symlinks:
-    site: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,2 +1,2 @@
 ---
-fixtures:
+fixtures: {}

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -86,7 +86,7 @@ jobs:
           bundle exec rake pkg:compare_latest_tag[,true]
           bundle exec rake pkg:create_tag_changelog
       - name: 'Test-build the Puppet module'
-        run: 'bundle exec pdk build --force'
+        run: 'bundle exec rake pupmod:build'
 
   spec-tests:
     name: 'Puppet Spec'
@@ -95,9 +95,19 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 8.x'
+          - label: 'OpenVox 8.x (Ruby 3.2)'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'
+            experimental: false
+          - label: 'OpenVox 8.x (Ruby 3.4)'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.4'
+            experimental: false
+          # OpenVox 9 is unreleased; preview the future Ruby 4.0 / OpenVox 9
+          # combo by running the OpenVox 8 gem on Ruby 4.0.
+          - label: 'OpenVox 9.x preview (Ruby 4.0, OpenVox 8 gem)'
+            puppet_version: '~> 8.0'
+            ruby_version: '4.0'
             experimental: false
       fail-fast: false
     env:

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   releng-checks:

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -55,14 +55,14 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake pkg:check_version
       - run: bundle exec rake pkg:compare_latest_tag
       - run: bundle exec rake pkg:create_tag_changelog
       - run: bundle exec rake metadata_lint
       - name: "Test that Puppet module can build"
-        run: "bundle exec pdk build --force"
+        run: "bundle exec rake pupmod:build"
 
 
   create-github-release:
@@ -180,10 +180,10 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: Build Puppet module (PDK)
-        run: bundle exec pdk build --force
+        run: bundle exec rake pupmod:build
       - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
           curl -X POST --silent --show-error --fail \

--- a/Gemfile
+++ b/Gemfile
@@ -6,37 +6,29 @@
 # ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS', 'https://rubygems.org').split(%r{[, ]+})
 
-ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
-
 gem_sources.each { |gem_source| source gem_source }
 
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.88.0'
+  # rubocop, rubocop-rake, and rubocop-rspec are pulled in and version-pinned by
+  # voxpupuli-test (via simp-rake-helpers); pinning them here conflicts with its
+  # constraints. rubocop-performance is not a voxpupuli-test dependency, so it
+  # stays explicit.
   gem 'rubocop-performance', '~> 1.26.0'
-  gem 'rubocop-rake', '~> 0.7.0'
-  gem 'rubocop-rspec', '~> 3.10.0'
 end
 
 group :test do
   puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
   openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
-  major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
   gem 'hiera-puppet-helper'
-  # renovate: datasource=rubygems versioning=ruby
-  gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
-  # Temporarily include both openvox and puppet gems until the puppet dependency is removed from other gems
-  ['openvox', 'puppet'].each do |gem_name|
-    gem gem_name, binding.local_variable_get("#{gem_name}_version".to_sym)
-  end
-  gem 'puppetlabs_spec_helper', '~> 8.0.0'
-  gem 'puppet-strings'
+  gem 'openvox', openvox_version
+  gem 'openvox-strings'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-puppet'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.24.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
   # renovate: datasource=rubygems versioning=ruby
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
   gem 'syslog', require: false
@@ -53,7 +45,7 @@ group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 2.0.0')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 3.1')
 end
 
 # Evaluate extra gemfiles if they exist

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
 require 'simp/rake/pupmod/helpers'
-require 'puppet-strings/tasks'
+require 'openvox-strings/tasks'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))

--- a/spec/classes/site_spec.rb
+++ b/spec/classes/site_spec.rb
@@ -15,7 +15,9 @@ describe 'site' do
   context 'on supported operating systems' do
     on_supported_os.each do |_os, _facts|
       context 'default params' do
-        it { expect(true).to be_truthy } # rubocop:disable RSpec/ExpectActual
+        it 'has no code to test' do
+          skip 'This module intentionally contains no code'
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@
 # The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'voxpupuli/test/spec_helper'
 require 'rspec-puppet'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts


### PR DESCRIPTION
## Summary

Round 2 of the module refresh: migrate the test toolchain off the `puppet` gem onto the OpenVox stack, and add a Ruby 4.0 / OpenVox 9 preview to CI. Mirrors `rubygem-simp-rake-helpers` and `rubygem-simp-beaker-helpers`.

No `metadata.json` version bump or `CHANGELOG` entry: build/test-tooling changes with no end-user-visible effect.

## Changes

- **Gemfile**: `openvox` only (drop `puppet`); `puppet-strings` -> `openvox-strings` (removes the transitive `puppet` and `facter` gems); drop `pdk` and `puppetlabs_spec_helper`; let `voxpupuli-test` manage rubocop/-rake/-rspec; require `simp-rake-helpers ~> 6.0` and `simp-beaker-helpers ~> 3.1`
- **Rakefile**: `require 'openvox-strings/tasks'` (where applicable)
- **spec/spec_helper.rb**: `require 'voxpupuli/test/spec_helper'`
- **.fixtures.yml**: drop the self-referencing `"#{source_dir}"` symlink (puppet_fixtures auto-creates it and does not interpolate that token)
- **pr_tests.yml**: test OpenVox 8 on Ruby 3.2 and 3.4, plus a **Ruby 4.0 / OpenVox 9 preview**; build with `rake pupmod:build`
- **tag_deploy.yml**: build with `rake pupmod:build`; deploy Ruby -> `3.4.9` (openvox requires Ruby >= 3.1)
- **REFERENCE.md**: regenerated with `openvox-strings` (where it changed)

Verified locally: the resolved bundle contains no `puppet` or `facter` gem. The Ruby 4.0 preview passes in CI on the pilot module (pupmod-simp-at#114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)